### PR TITLE
Fix: Handle raw PCM audio stream from ElevenLabs API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,4 +27,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>elevenlabsApp.Main</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/elevenlabsApp/service/AudioPlayerService.java
+++ b/src/main/java/elevenlabsApp/service/AudioPlayerService.java
@@ -7,7 +7,17 @@ import java.io.InputStream;
 public class AudioPlayerService {
 
     public void play(InputStream inputStream) throws LineUnavailableException, IOException, UnsupportedAudioFileException {
-        try (AudioInputStream audioStream = AudioSystem.getAudioInputStream(inputStream)) {
+        // Define the audio format for pcm_24000
+        // Sample Rate: 24000 Hz, Sample Size: 16 bits, Channels: 1 (Mono), Signed: true, Big Endian: true
+        AudioFormat format = new AudioFormat(24000, 16, 1, true, true);
+
+        // The total length of the audio data in bytes.
+        long length = inputStream.available();
+        // The length in sample frames.
+        long frameLength = length / format.getFrameSize();
+
+
+        try (AudioInputStream audioStream = new AudioInputStream(inputStream, format, frameLength)) {
             Clip clip = AudioSystem.getClip();
 
             // Add a listener to close the clip when it finishes playing
@@ -19,6 +29,16 @@ public class AudioPlayerService {
 
             clip.open(audioStream);
             clip.start();
+
+            // Wait for the clip to finish playing. This is a blocking call.
+            // In a real GUI app, you'd handle this asynchronously.
+            while (clip.isRunning()) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
         }
     }
 }

--- a/src/main/java/elevenlabsApp/service/ElevenLabsService.java
+++ b/src/main/java/elevenlabsApp/service/ElevenLabsService.java
@@ -13,7 +13,7 @@ public class ElevenLabsService {
     private final OkHttpClient client = new OkHttpClient();
 
     public InputStream textToSpeech(String apiKey, String text) throws IOException, ApiException {
-        String url = API_URL.replace("{voice_id}", VOICE_ID);
+        String urlWithParams = API_URL.replace("{voice_id}", VOICE_ID) + "?output_format=pcm_24000";
 
         JSONObject json = new JSONObject();
         json.put("text", text);
@@ -23,7 +23,7 @@ public class ElevenLabsService {
         RequestBody body = RequestBody.create(json.toString(), MediaType.get("application/json"));
 
         Request request = new Request.Builder()
-                .url(url)
+                .url(urlWithParams)
                 .header("xi-api-key", apiKey)
                 .header("Content-Type", "application/json")
                 .post(body)


### PR DESCRIPTION
Updates AudioPlayerService to correctly interpret the raw PCM stream from the ElevenLabs API by explicitly defining the AudioFormat. This resolves the 'Stream of unsupported format' error during playback.