### PR TITLE
This commit adds new functionality to the settings dialog based on us…

### DIFF
--- a/src/main/resources/default_settings.properties
+++ b/src/main/resources/default_settings.properties
@@ -1,0 +1,5 @@
+# Default Voice Settings
+stability=0.75
+similarityBoost=0.75
+style=0.0
+useSpeakerBoost=true


### PR DESCRIPTION
…er feedback.

- A non-editable text field has been added to the settings dialog to display the `voice_id` of the currently selected voice. This provides clarity for the user.
- A "Defaults" button has been added, allowing the user to reset the detailed voice settings (`stability`, `similarity_boost`, etc.) to a predefined state.
- The default settings are loaded from a new `default_settings.properties` file located in the `src/main/resources` directory.