### PR TITLE
feat: Add maven-assembly-plugin to build executable fat JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,30 @@
                     <mainClass>elevenlabsApp.Main</mainClass>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>elevenlabsApp.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This change adds the `maven-assembly-plugin` to the `pom.xml` file.

The plugin is configured to create a single, standalone JAR file that includes all the project's dependencies. This allows the application to be run from the command line using `java -jar` without needing to manually manage the classpath.

The main class is correctly set to `elevenlabsApp.Main`.